### PR TITLE
Generate report based on namespaces #68

### DIFF
--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -1,6 +1,9 @@
 -- This function generates a report based on a given frequency
 -- This file should only be run once, in order to register the function
 
+-- update table reports to add new column for namespace
+-- ALTER TABLE reports
+-- ADD COLUMN namespace TEXT;
 CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
   returns integer
   as $$
@@ -25,6 +28,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
         reports (
           frequency,
           interval_start,
+          namesapce,
           pod_usage_cpu_core_seconds,
           pod_request_cpu_core_seconds,
           pod_limit_cpu_core_seconds,
@@ -39,6 +43,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
       SELECT
         ' || quote_literal(frequency) || ' as frequency,
         ' || quote_literal(interval_start_date) ||' as interval_start,
+        namespace,
         SUM(pod_usage_cpu_core_seconds::double precision) as pod_usage_cpu_core_seconds,
         SUM(pod_request_cpu_core_seconds::double precision) as pod_request_cpu_core_seconds,
         SUM(pod_limit_cpu_core_seconds::double precision) as pod_limit_cpu_core_seconds,
@@ -50,6 +55,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
         SUM(node_capacity_memory_bytes::double precision) as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds::double precision) as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || ';';
+      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '
+      GROUP BY namespace;';
   return 0;
 end; $$ LANGUAGE plpgsql

--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -28,7 +28,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
         reports (
           frequency,
           interval_start,
-          namesapce,
+          namespace,
           pod_usage_cpu_core_seconds,
           pod_request_cpu_core_seconds,
           pod_limit_cpu_core_seconds,
@@ -56,6 +56,23 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
         SUM(node_capacity_memory_byte_seconds::double precision) as  node_capacity_memory_byte_seconds
       FROM logs_2
       WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '
-      GROUP BY namespace;';
+      GROUP BY namespace
+      UNION
+      SELECT
+        ' || quote_literal(frequency) || ' as frequency,
+        ' || quote_literal(interval_start_date) ||' as interval_start,
+        ''TOTAL'' as namespace,
+        SUM(pod_usage_cpu_core_seconds::double precision) as pod_usage_cpu_core_seconds,
+        SUM(pod_request_cpu_core_seconds::double precision) as pod_request_cpu_core_seconds,
+        SUM(pod_limit_cpu_core_seconds::double precision) as pod_limit_cpu_core_seconds,
+        SUM(pod_usage_memory_byte_seconds::double precision) as pod_usage_memory_byte_seconds,
+        SUM(pod_request_memory_byte_seconds::double precision) as pod_request_memory_byte_seconds,
+        SUM(pod_limit_memory_byte_seconds::double precision) as pod_limit_memory_byte_seconds,
+        SUM(node_capacity_cpu_cores::double precision) as node_capacity_cpu_cores,
+        SUM(node_capacity_cpu_core_seconds::double precision) as  node_capacity_cpu_core_seconds,
+        SUM(node_capacity_memory_bytes::double precision) as  node_capacity_memory_bytes,
+        SUM(node_capacity_memory_byte_seconds::double precision) as  node_capacity_memory_byte_seconds
+      FROM logs_2
+      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '';
   return 0;
 end; $$ LANGUAGE plpgsql

--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -4,6 +4,10 @@
 -- update table reports to add new column for namespace
 -- ALTER TABLE reports
 -- ADD COLUMN namespace TEXT;
+--
+-- Define type report_frequency
+-- CREATE TYPE report_frequency AS ENUM ('day', 'week', 'month');
+
 CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
   returns integer
   as $$


### PR DESCRIPTION
Update SQL function for #68.
Example result:
|frequency|interval_start     |pod_usage_cpu_core_seconds|pod_request_cpu_core_seconds|pod_limit_cpu_core_seconds|pod_usage_memory_byte_seconds|pod_request_memory_byte_seconds|pod_limit_memory_byte_seconds|node_capacity_cpu_cores|node_capacity_cpu_core_seconds|node_capacity_memory_bytes|node_capacity_memory_byte_second|namespace                                       |
|---------|-------------------|--------------------------|----------------------------|--------------------------|-----------------------------|-------------------------------|-----------------------------|-----------------------|------------------------------|--------------------------|--------------------------------|------------------------------------------------|
|week     |2021-06-13 00:00:00|21814.108174              |21654                       |36000                     |313573579161600              |228201678766080                |343785288499200              |1024                   |3686400                       |6217724735488             |22383809047756800               |openshift-logging                               |
|week     |2021-06-13 00:00:00|64.665953                 |                            |                          |5949680271360                |                               |                             |96                     |345600                        |946508443648              |3407430397132800                |openshift-serverless                            |
|week     |2021-06-13 00:00:00|1558.206799               |476.40000000000015          |                          |11646881464320               |2497708032000                  |                             |896                    |3225600                       |4189030952960             |15080511430656000               |openshift-marketplace                           |
