### PR TITLE
format metrics into human readable TEXT

### DIFF
--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -25,31 +25,51 @@ CREATE OR REPLACE FUNCTION generate_report (frequency report_frequency)
         reports (
           frequency,
           interval_start,
-          pod_usage_cpu_core_seconds,
-          pod_request_cpu_core_seconds,
-          pod_limit_cpu_core_seconds,
+          namespace,
+          pod_usage_cpu_core_time,
+          pod_request_cpu_core_time,
+          pod_limit_cpu_core_time,
           pod_usage_memory_byte_seconds,
           pod_request_memory_byte_seconds,
           pod_limit_memory_byte_seconds,
           node_capacity_cpu_cores,
-          node_capacity_cpu_core_seconds,
+          node_capacity_cpu_core_time,
           node_capacity_memory_bytes,
           node_capacity_memory_byte_second
         )
       SELECT
         ' || quote_literal(frequency) || ' as frequency,
         ' || quote_literal(interval_start_date) ||' as interval_start,
-        SUM(pod_usage_cpu_core_seconds::double precision) as pod_usage_cpu_core_seconds,
-        SUM(pod_request_cpu_core_seconds::double precision) as pod_request_cpu_core_seconds,
-        SUM(pod_limit_cpu_core_seconds::double precision) as pod_limit_cpu_core_seconds,
-        SUM(pod_usage_memory_byte_seconds::double precision) as pod_usage_memory_byte_seconds,
-        SUM(pod_request_memory_byte_seconds::double precision) as pod_request_memory_byte_seconds,
-        SUM(pod_limit_memory_byte_seconds::double precision) as pod_limit_memory_byte_seconds,
-        SUM(node_capacity_cpu_cores::double precision) as node_capacity_cpu_cores,
-        SUM(node_capacity_cpu_core_seconds::double precision) as  node_capacity_cpu_core_seconds,
-        SUM(node_capacity_memory_bytes::double precision) as  node_capacity_memory_bytes,
-        SUM(node_capacity_memory_byte_seconds::double precision) as  node_capacity_memory_byte_seconds
+        namespace,
+        TO_CHAR((SUM(pod_usage_cpu_core_seconds::double precision)      || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_usage_cpu_core_time,
+        TO_CHAR((SUM(pod_request_cpu_core_seconds::double precision)    || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_request_cpu_core_time,
+        TO_CHAR((SUM(pod_limit_cpu_core_seconds::double precision)      || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_limit_cpu_core_time,
+        pg_size_pretty(SUM(pod_usage_memory_byte_seconds::double precision)::numeric)                                                   as pod_usage_memory_byte_seconds,
+        pg_size_pretty(SUM(pod_request_memory_byte_seconds::double precision)::numeric)                                                 as pod_request_memory_byte_seconds,
+        pg_size_pretty(SUM(pod_limit_memory_byte_seconds::double precision)::numeric)                                                   as pod_limit_memory_byte_seconds,
+        SUM(node_capacity_cpu_cores::double precision)                                                                                  as node_capacity_cpu_cores,
+        TO_CHAR((SUM(node_capacity_cpu_core_seconds::double precision)  || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as node_capacity_cpu_core_time,
+        pg_size_pretty(SUM(node_capacity_memory_bytes::double precision)::numeric)                                                      as node_capacity_memory_bytes,
+        pg_size_pretty(SUM(node_capacity_memory_byte_seconds::double precision)::numeric)                                               as node_capacity_memory_byte_second
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || ';';
+      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '
+      GROUP BY namespace
+      UNION
+  	  SELECT
+        ' || quote_literal(frequency) || ' as frequency,
+        ' || quote_literal(interval_start_date) ||' as interval_start,
+        ''TOTAL'' as namespace,
+        TO_CHAR((SUM(pod_usage_cpu_core_seconds::double precision)      || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_usage_cpu_core_time,
+        TO_CHAR((SUM(pod_request_cpu_core_seconds::double precision)    || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_request_cpu_core_time,
+        TO_CHAR((SUM(pod_limit_cpu_core_seconds::double precision)      || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as pod_limit_cpu_core_time,
+        pg_size_pretty(SUM(pod_usage_memory_byte_seconds::double precision)::numeric)                                                   as pod_usage_memory_byte_seconds,
+        pg_size_pretty(SUM(pod_request_memory_byte_seconds::double precision)::numeric)                                                 as pod_request_memory_byte_seconds,
+        pg_size_pretty(SUM(pod_limit_memory_byte_seconds::double precision)::numeric)                                                   as pod_limit_memory_byte_seconds,
+        SUM(node_capacity_cpu_cores::double precision)                                                                                  as node_capacity_cpu_cores,
+        TO_CHAR((SUM(node_capacity_cpu_core_seconds::double precision)  || '' second'')::interval, '||'''HH24:MI:SS.MS'''||')          as node_capacity_cpu_core_time,
+        pg_size_pretty(SUM(node_capacity_memory_bytes::double precision)::numeric)                                                      as node_capacity_memory_bytes,
+        pg_size_pretty(SUM(node_capacity_memory_byte_seconds::double precision)::numeric)                                               as node_capacity_memory_byte_second
+      FROM logs_2
+      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '';
   return 0;
 end; $$ LANGUAGE plpgsql


### PR DESCRIPTION
Example Result:
| frequency | interval_start      | namespace                                        | pod_usage_cpu_core_time | pod_request_cpu_core_time | pod_limit_cpu_core_time | pod_usage_memory_byte_seconds | pod_request_memory_byte_seconds | pod_limit_memory_byte_seconds | node_capacity_cpu_cores | node_capacity_cpu_core_time | node_capacity_memory_bytes | node_capacity_memory_byte_second |
| :-------- | ------------------- | ------------------------------------------------ | ----------------------- | ------------------------- | ----------------------- | ----------------------------- | ------------------------------- | ----------------------------- | ----------------------- | --------------------------- | -------------------------- | -------------------------------- |
| week      | 2021-06-13 00:00:00 | knative-eventing                                 | 00:04:21.800            | 00:25:12.000              | 00:12:00.000            | 4334 GB                       | 1477 GB                         | 3600 GB                       | 256                     | 256:00:00.000               | 2393 GB                    | 8412 TB                          |
| week      | 2021-06-13 00:00:00 | thoth-frontend-prod                              | 00:01:25.041            | 06:06:00.000              | 06:45:00.000            | 3728 GB                       | 30 TB                           | 32 TB                         | 288                     | 288:00:00.000               | 2015 GB                    | 7083 TB                          |
| week      | 2021-06-13 00:00:00 | openshift-logging                                | 06:03:34.108            | 06:00:54.000              | 10:00:00.000            | 285 TB                        | 208 TB                          | 313 TB                        | 1024                    | 1024:00:00.000              | 5791 GB                    | 20358 TB                         |
| week      | 2021-06-13 00:00:00 | TOTAL                                            | 35:00:32.996            | 294:12:35.400             | 569:43:34.200           | 2336 TB                       | 2161 TB                         | 4240 TB                       | 75168                   | 75168:00:00.000             | 417 TB                     | 1502534 TB                       |

