### PR TITLE
fix report timing

### DIFF
--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -9,16 +9,16 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
     interval_end_date timestamp with time zone;
   begin
   	if frequency = 'day' then
-    	interval_start_date := date_trunc('day', current_date at time zone 'UTC');
-        interval_end_date := date_trunc('day', current_date at time zone 'UTC') + '23 hours 59 minutes';
+    	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '24 hours';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
   	if frequency = 'week' then
-        interval_start_date := (date_trunc('week', current_date at time zone 'UTC') + '-1 days')::date;
-        interval_end_date := (date_trunc('week', current_date at time zone 'UTC') + '5 days')::date;
+        interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '7 days';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
     if frequency = 'month' then
-    	interval_start_date := date_trunc('month', current_date at time zone 'UTC');
-        interval_end_date := date_trunc('month', current_date at time zone 'UTC') + '1 month';
+    	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '1 month';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
     EXECUTE '
       INSERT INTO
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
         SUM(node_capacity_memory_bytes)       as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds)as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '
+      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start < ' || quote_literal(interval_end_date) || '
       GROUP BY namespace
       UNION
       SELECT
@@ -70,6 +70,6 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
         SUM(node_capacity_memory_bytes) as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds) as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '';
+      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start <' || quote_literal(interval_end_date) || '';
   return 0;
 end; $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fix bugs with report timing: 
1. Ensure the report collects all metrics for a **complete** day from 00:00 to 23:59. Report generations in the middle of a day will be truncated to generate reports for the day before to avoid incomplete data.
2. Change month and week reports to collect metrics for the past one week and one month respectively. This allows users to define the start of the month or week by defining the report generation time in the Cronjob schedule.  

Running a day report at any time of the day will create a daily report for the day before. Cronjob schedule should be set to `@ midnight`.
Ex: Running at 2021-09-09 00:08:00 will collect all metrics in from 2021-09-08 00:00:00 to 2021-09-08 23:59:59 inclusive.
