### PR TITLE
fix report timing

### DIFF
--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -1,26 +1,40 @@
 -- This function generates a report based on a given frequency
 -- This file should only be run once, in order to register the function
 
-CREATE OR REPLACE FUNCTION generate_report (frequency text)
-  returns integer
+CREATE OR REPLACE FUNCTION generate_report (frequency_ text)
+  returns TABLE (
+	frequency text,
+	interval_start text,
+	pod_usage_cpu_core_seconds double precision,
+	pod_request_cpu_core_seconds double precision,
+	pod_limit_cpu_core_seconds double precision,
+	pod_usage_memory_byte_seconds double precision,
+	pod_request_memory_byte_seconds double precision,
+	pod_limit_memory_byte_seconds double precision,
+	node_capacity_cpu_cores double precision,
+	node_capacity_cpu_core_seconds double precision,
+	node_capacity_memory_bytes double precision,
+	node_capacity_memory_byte_seconds double precision,
+	namespace text
+)
   as $$
   declare
     interval_start_date timestamp with time zone;
     interval_end_date timestamp with time zone;
   begin
-  	if frequency = 'day' then
+  	if frequency_ = 'day' then
     	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '24 hours';
         interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
-  	if frequency = 'week' then
+  	if frequency_ = 'week' then
         interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '7 days';
         interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
-    if frequency = 'month' then
+    if frequency_ = 'month' then
     	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '1 month';
         interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
-    EXECUTE '
+    RETURN QUERY EXECUTE '
       INSERT INTO
         reports (
           frequency,
@@ -38,7 +52,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
           node_capacity_memory_byte_seconds
         )
       SELECT
-        ' || quote_literal(frequency) || ' as frequency,
+        ' || quote_literal(frequency_) || ' as frequency,
         ' || quote_literal(interval_start_date) ||' as interval_start,
         namespace,
         SUM(pod_usage_cpu_core_seconds)       as pod_usage_cpu_core_seconds,
@@ -56,7 +70,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
       GROUP BY namespace
       UNION
       SELECT
-        ' || quote_literal(frequency) || ' as frequency,
+        ' || quote_literal(frequency_) || ' as frequency,
         ' || quote_literal(interval_start_date) ||' as interval_start,
         ''TOTAL'' as namespace,
         SUM(pod_usage_cpu_core_seconds) as pod_usage_cpu_core_seconds,
@@ -70,6 +84,5 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
         SUM(node_capacity_memory_bytes) as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds) as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start <' || quote_literal(interval_end_date) || '';
-  return 0;
+      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start <' || quote_literal(interval_end_date) || ' returning *';
 end; $$ LANGUAGE plpgsql;

--- a/scripts/reports/generate_report.psql
+++ b/scripts/reports/generate_report.psql
@@ -9,16 +9,16 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
     interval_end_date timestamp with time zone;
   begin
   	if frequency = 'day' then
-    	interval_start_date := date_trunc('day', current_date at time zone 'UTC');
-        interval_end_date := date_trunc('day', current_date at time zone 'UTC') + '23 hours 59 minutes';
+    	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '24 hours';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
   	if frequency = 'week' then
-        interval_start_date := (date_trunc('week', current_date at time zone 'UTC') + '-1 days')::date;
-        interval_end_date := (date_trunc('week', current_date at time zone 'UTC') + '5 days')::date;
+        interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '7 days';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
     if frequency = 'month' then
-    	interval_start_date := date_trunc('month', current_date at time zone 'UTC');
-        interval_end_date := date_trunc('month', current_date at time zone 'UTC') + '1 month';
+    	interval_start_date := date_trunc('day', current_date at time zone 'UTC') - interval '1 month';
+        interval_end_date := date_trunc('day', current_date at time zone 'UTC');
     end if;
     EXECUTE '
       INSERT INTO
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
         SUM(node_capacity_memory_bytes)       as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds)as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '
+      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start < ' || quote_literal(interval_end_date) || '
       GROUP BY namespace
       UNION
       SELECT
@@ -70,6 +70,6 @@ CREATE OR REPLACE FUNCTION generate_report (frequency text)
         SUM(node_capacity_memory_bytes) as  node_capacity_memory_bytes,
         SUM(node_capacity_memory_byte_seconds) as  node_capacity_memory_byte_seconds
       FROM logs_2
-      WHERE interval_start between ' || quote_literal(interval_start_date) || ' and ' || quote_literal(interval_end_date) || '';
+      WHERE interval_start >= ' || quote_literal(interval_start_date) || ' and interval_start <' || quote_literal(interval_end_date) || '';
   return 0;
 end; $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Fix bugs with report timing:

Ensure the report collects all metrics for a complete day from 00:00 to 23:59. Report generations in the middle of a day will be truncated to generate reports for the day before to avoid incomplete data.
Change month and week reports to collect metrics for the past one week and one month respectively. This allows users to define the start of the month or week by defining the report generation time in the Cronjob schedule.
Running a day report at any time of the day will create a daily report for the day before. Cronjob schedule should be set to `@ midnight`.
Ex: Running at 2021-09-09 00:08:00 will collect all metrics in from 2021-09-08 00:00:00 to 2021-09-08 23:59:59 inclusive.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200965343172825/1200984429438312) by [Unito](https://www.unito.io)
